### PR TITLE
Change manual quoting to shQuote

### DIFF
--- a/R/remove_pages.R
+++ b/R/remove_pages.R
@@ -72,8 +72,8 @@ remove_pages <- function(rmpages, input_filepath = NULL, output_directory = NULL
   # Take the filepath arguments and format them for use in a system command
   selected_pages <- (unlist(selected_pages))
   selected_pages <- paste(selected_pages,collapse=" ")
-  output_filepath <- paste0('"', output_filepath, '"')
-  quoted_names <- paste0('"', input_filepath, '"')
+  output_filepath <- shQuote(output_filepath)
+  quoted_names <- shQuote(input_filepath)
   input_filepath <- paste(quoted_names, collapse = " ")
   # Construct a system command to pdftk
   system_command <- paste("pdftk",

--- a/R/split_pdf.R
+++ b/R/split_pdf.R
@@ -43,8 +43,8 @@ split_pdf <- function(input_filepath = NULL, output_directory = NULL) {
   }
 
   # Take the filepath arguments and format them for use in a system command
-  output_filepath <- paste0('"', output_directory,"/page_%04d.pdf", '"')
-  quoted_names <- paste0('"', input_filepath, '"')
+  output_filepath <- shQuote(paste0(output_directory,"/page_%04d.pdf"))
+  quoted_names <- shQuote( input_filepath)
   input_filepath <- paste(quoted_names, collapse = " ")
 
   # Construct a system command to pdftk

--- a/R/staple_pdf.R
+++ b/R/staple_pdf.R
@@ -45,9 +45,9 @@ staple_pdf <- function(input_directory = NULL, output_filename = "Full_pdf", out
   output_filepath<- file.path(output_directory, paste(output_filename,".pdf",  sep = ""))
 
   # Take the filepath arguments and format them for use in a system command
-  quoted_names <- paste0('"', input_filepaths, '"')
+  quoted_names <- shQuote(input_filepaths)
   file_list <- paste(quoted_names, collapse = " ")
-  output_filepath <- paste0('"', output_filepath, '"')
+  output_filepath <- shQuote(output_filepath)
 
   # Construct a system command to pdftk
   system_command <- paste("pdftk",


### PR DESCRIPTION
Inputs for pdftk were manually quoted by adding `"`s to the sides. This approach is not generalisable as filenames can also have `"`s. I have changed all instances of this with `shQuote` which is the base R way of making sure everything is quoted in a valid manner.