### PR TITLE
split_pdf and split_from changes

### DIFF
--- a/R/split_from.R
+++ b/R/split_from.R
@@ -48,10 +48,13 @@ split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL, p
   }
 
   parts <- length(pg_num) + 1
-  splitPoints = c(0,pg_num,'end')
+  splitPoints <- c(0,pg_num,'end')
+  digits <- floor(log(parts))
 
   for (i in seq_len(parts)){
-    output_filepath <- file.path(output_directory, paste(prefix,i,".pdf",  sep = ""))
+    output_filepath <- file.path(output_directory,
+                                 paste(prefix, stringr::str_pad(i,digits, pad = '0'),
+                                       ".pdf",  sep = ""))
 
     system_command <- paste("pdftk",
                             shQuote(input_filepath),

--- a/R/split_from.R
+++ b/R/split_from.R
@@ -27,13 +27,13 @@
 #' print(xyplot(iris[,1] ~ iris[,i], data = iris))
 #' dev.off()
 #' }
-#' sstaple_pdf(input_directory = dir, output_filepath = 'Full_pdf.pdf')
-#' input_path <- file.path(dir, paste("Full_pdf.pdf",  sep = ""))
+#' staple_pdf(input_directory = dir, output_filepath = file.path(dir, 'Full_pdf.pdf'))
+#' input_path <- file.path(dir, "Full_pdf.pdf")
 #' split_from(pg_num=2, input_filepath = input_path ,output_directory = dir )
 #' }
 #' @export
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL) {
+split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL, prefix = 'part') {
 
   assertthat::assert_that(assertthat::is.number(pg_num))
 
@@ -48,8 +48,8 @@ split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL) {
   }
 
   # Take the filepath arguments and format them for use in a system command
-  output_filepath_1 <- file.path(output_directory, paste("part1.pdf",  sep = ""))
-  output_filepath_2 <- file.path(output_directory, paste("part2.pdf",  sep = ""))
+  output_filepath_1 <- file.path(output_directory, paste(prefix,"1.pdf",  sep = ""))
+  output_filepath_2 <- file.path(output_directory, paste(prefix,"2.pdf",  sep = ""))
 
   # Construct a system command to pdftk to save the first part
   system_command <- paste("pdftk",

--- a/R/split_from.R
+++ b/R/split_from.R
@@ -1,11 +1,11 @@
-#' Splits single input PDF document into two parts from a given point
+#' Splits single input PDF document into parts from given points
 #'
 #' @description If the toolkit Pdftk is available in the
 #' system, it will be called to Split a single input PDF document
 #' into two parts from a given point
 #'
 #' See the reference for detailed usage of \code{pdftk}.
-#' @param pg_num a nonnegative integer. Split the pdf document into two from this page number.
+#' @param pg_num A vector of non-negative integers. Split the pdf document into parts from the numbered pages.
 #' @param input_filepath the path of the input PDF file.
 #' The default is set to NULL. IF NULL, it  prompt the user to
 #' select the folder interactively.
@@ -35,7 +35,7 @@
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
 split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL, prefix = 'part') {
 
-  assertthat::assert_that(assertthat::is.number(pg_num))
+  assertthat::assert_that(is.numeric(pg_num))
 
   if(is.null(input_filepath)){
     #Choose the pdf file interactively
@@ -47,31 +47,22 @@ split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL, p
     output_directory<- tcltk::tk_choose.dir(caption = "Select directory to save output")
   }
 
-  # Take the filepath arguments and format them for use in a system command
-  output_filepath_1 <- file.path(output_directory, paste(prefix,"1.pdf",  sep = ""))
-  output_filepath_2 <- file.path(output_directory, paste(prefix,"2.pdf",  sep = ""))
+  parts <- length(pg_num) + 1
+  splitPoints = c(0,pg_num,'end')
 
-  # Construct a system command to pdftk to save the first part
-  system_command <- paste("pdftk",
-                          shQuote(input_filepath),
-                          "cat",
-                          paste("1-",pg_num, sep = ""),
-                          "output",
-                          shQuote(output_filepath_1),
-                          sep = " ")
-  # Invoke the command
-  system(command = system_command)
+  for (i in seq_len(parts)){
+    output_filepath <- file.path(output_directory, paste(prefix,i,".pdf",  sep = ""))
 
-  # Construct a system command to pdftk to save the second part
-  system_command <- paste("pdftk",
-                          shQuote(input_filepath),
-                          "cat",
-                          paste(pg_num+1, "-end",sep = ""),
-                          "output",
-                          shQuote(output_filepath_2),
-                          sep = " ")
-  # Invoke the command
-  system(command = system_command)
+    system_command <- paste("pdftk",
+                            shQuote(input_filepath),
+                            "cat",
+                            paste(as.integer(splitPoints[i])+1,'-',splitPoints[i+1], sep = ""),
+                            "output",
+                            shQuote(output_filepath),
+                            sep = " ")
+
+    system(command = system_command)
+  }
 
 }
 

--- a/R/split_pdf.R
+++ b/R/split_pdf.R
@@ -25,7 +25,7 @@
 #' print(xyplot(iris[,1] ~ iris[,i], data = iris))
 #' dev.off()
 #' }
-#' staple_pdf(input_directory = dir, output_filepath = 'Full_pdf.pdf')
+#' staple_pdf(input_directory = dir, output_filepath = file.path(dir, 'Full_pdf.pdf'))
 #' split_pdf(input_filepath = file.path(dir, paste("Full_pdf.pdf",  sep = "")),output_directory = dir )
 #' }
 #' @export

--- a/R/split_pdf.R
+++ b/R/split_pdf.R
@@ -31,7 +31,7 @@
 #' @export
 #' @import utils
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-split_pdf <- function(input_filepath = NULL, output_directory = NULL) {
+split_pdf <- function(input_filepath = NULL, output_directory = NULL, prefix = 'page_') {
 
   if(is.null(input_filepath)){
     #Choose the pdf file interactively
@@ -43,8 +43,22 @@ split_pdf <- function(input_filepath = NULL, output_directory = NULL) {
     output_directory<- tcltk::tk_choose.dir(caption = "Select directory to save output")
   }
 
+  # Getting the page count to add the correct amout of zeroes to make it scalable
+  metadataTemp <- tempfile()
+  # Construct a system command to pdftk to get number of pages
+  system_command <- paste("pdftk",
+                          shQuote(input_filepath),
+                          "dump_data",
+                          "output",
+                          shQuote(metadataTemp))
+  system(command = system_command)
+  page_length <- as.numeric(stringr::str_extract(grep( "NumberOfPages", paste0(readLines(metadataTemp)),
+                                                       value = TRUE), "\\d+$"))
+  digits <- max(floor(log(page_length)),4)
+
+
   # Take the filepath arguments and format them for use in a system command
-  output_filepath <- shQuote(paste0(output_directory,"/page_%04d.pdf"))
+  output_filepath <- shQuote(paste0(output_directory, "/", prefix, "%0",digits,"d.pdf"))
 
   # Construct a system command to pdftk
   system_command <- paste("pdftk",

--- a/man/rotate_pages.Rd
+++ b/man/rotate_pages.Rd
@@ -4,8 +4,8 @@
 \alias{rotate_pages}
 \title{Rotate selected pages of a pdf file}
 \usage{
-rotate_pages(rotatepages, page_rotation, input_filepath = NULL,
-  output_filepath = NULL)
+rotate_pages(rotatepages, page_rotation = c(0, 90, 180, 270),
+  input_filepath = NULL, output_filepath = NULL)
 }
 \arguments{
 \item{rotatepages}{a vector of page numbers to be rotated}

--- a/man/rotate_pdf.Rd
+++ b/man/rotate_pdf.Rd
@@ -4,7 +4,8 @@
 \alias{rotate_pdf}
 \title{Rotate entire pdf document}
 \usage{
-rotate_pdf(page_rotation, input_filepath = NULL, output_filepath = NULL)
+rotate_pdf(page_rotation = c(0, 90, 180, 270), input_filepath = NULL,
+  output_filepath = NULL)
 }
 \arguments{
 \item{page_rotation}{An integer value from the vector c(0, 90, 180, 270).

--- a/man/split_from.Rd
+++ b/man/split_from.Rd
@@ -2,12 +2,13 @@
 % Please edit documentation in R/split_from.R
 \name{split_from}
 \alias{split_from}
-\title{Splits single input PDF document into two parts from a given point}
+\title{Splits single input PDF document into parts from given points}
 \usage{
-split_from(pg_num, input_filepath = NULL, output_directory = NULL)
+split_from(pg_num, input_filepath = NULL, output_directory = NULL,
+  prefix = "part")
 }
 \arguments{
-\item{pg_num}{a nonnegative integer. Split the pdf document into two from this page number.}
+\item{pg_num}{A vector of non-negative integers. Split the pdf document into parts from the numbered pages.}
 
 \item{input_filepath}{the path of the input PDF file.
 The default is set to NULL. IF NULL, it  prompt the user to
@@ -40,8 +41,8 @@ pdf(file.path(dir, paste("plot", i, ".pdf", sep = "")))
 print(xyplot(iris[,1] ~ iris[,i], data = iris))
 dev.off()
 }
-sstaple_pdf(input_directory = dir, output_filepath = 'Full_pdf.pdf')
-input_path <- file.path(dir, paste("Full_pdf.pdf",  sep = ""))
+staple_pdf(input_directory = dir, output_filepath = file.path(dir, 'Full_pdf.pdf'))
+input_path <- file.path(dir, "Full_pdf.pdf")
 split_from(pg_num=2, input_filepath = input_path ,output_directory = dir )
 }
 }

--- a/man/split_pdf.Rd
+++ b/man/split_pdf.Rd
@@ -4,7 +4,8 @@
 \alias{split_pdf}
 \title{Splits single input PDF document into individual pages.}
 \usage{
-split_pdf(input_filepath = NULL, output_directory = NULL)
+split_pdf(input_filepath = NULL, output_directory = NULL,
+  prefix = "page_")
 }
 \arguments{
 \item{input_filepath}{the path of the input PDF file.
@@ -37,7 +38,7 @@ pdf(file.path(dir, paste("plot", i, ".pdf", sep = "")))
 print(xyplot(iris[,1] ~ iris[,i], data = iris))
 dev.off()
 }
-staple_pdf(input_directory = dir, output_filepath = 'Full_pdf.pdf')
+staple_pdf(input_directory = dir, output_filepath = file.path(dir, 'Full_pdf.pdf'))
 split_pdf(input_filepath = file.path(dir, paste("Full_pdf.pdf",  sep = "")),output_directory = dir )
 }
 }


### PR DESCRIPTION
This includes a few changes

#### `split_pdf`

* Fixes to examples in `split_from` and `split_pdf`
* `split_pdf` now accepts a prefix to name the outputs. default behaviour isn't changed.
* `split_pdf` places more zeroes if the page count is longer than expected. Don't really think it'll come up in real life. Though if `digits <- max(floor(log(page_length)),4)` is changed to `digits <- floor(log(page_length))` on line 54, it won't try to fill all 4 digits if the file is smaller. Added the `max` clause to preserve the existing behaviour.

#### `split_from`

* `split_from` not accepts a prefix to name the outputs.
* `split_from`'s `pg_num` can be a vector now to split from multiple pages. if split into more than 10 pages, adds trailing zeros to the filenames
* existing behaviour isn't changed due to either of these changes, however the trailing 0 behaviour is inconsistent with the other function (`split_pdf`) that does something similar. Here 0s are added as needed, `split_pdf` it completes to 4 digits minimum. It wasn't possible to make them consistent without changing the existing behaviour. Either or none of them can be changed to fit the other on demand.