### PR TITLE
Changes to readme and staple_pdf()

### DIFF
--- a/R/staple_pdf.R
+++ b/R/staple_pdf.R
@@ -5,11 +5,13 @@
 #'
 #' See the reference for detailed usage of \code{pdftk}.
 #' @param input_directory the path of the input PDF files.
+#' The default is set to NULL. If NULL, it  prompt the user to
+#' select the folder interactively.
+#' @param input_files a vector of input PDF files. The default is set to NULL. If NULL and \code{input_directory} is also NULL, the user is propted to select a folder interactively.
+#' @param output_directory the path of the output PDF file.
 #' The default is set to NULL. IF NULL, it  prompt the user to
 #' select the folder interactively.
-#' @param output_filepath the path of the output output PDF file.
-#' The default is set to NULL. IF NULL, it  prompt the user to
-#' select the folder interactivelye.
+#' @param output_filename the name of the output PDF file. The default is full_pdf.pdf.
 #' @return this function returns a combined PDF document
 #' @author Priyanga Dilini Talagala
 #' @examples
@@ -25,34 +27,35 @@
 #' print(xyplot(iris[,1] ~ iris[,i], data = iris))
 #' dev.off()
 #' }
-#' output_file <- file.path(dir, paste('Full_pdf.pdf',  sep = ""))
+#' output_file <- file.path(dir, paste('full_pdf.pdf',  sep = ""))
 #' staple_pdf(input_directory = dir, output_file)
 #' }
 #' @export
 #' @importFrom tcltk tk_choose.dir
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-staple_pdf <- function(input_directory = NULL, output_filepath = NULL) {
-
-  if(is.null(input_directory)){
-    #Choose a folder interactively
-    input_directory<- tcltk::tk_choose.dir(caption = "Select directory which contains PDF fies")
+staple_pdf <- function(input_directory = NULL, input_files = NULL, output_filename = "full_pdf",
+                       output_directory = NULL)
+{
+  # set error if neither input_directory of input_files are null
+  if(!is.null(input_directory) & !is.null(input_files)){
+    stop("One of input_directory and input_files has to be NULL.")
   }
 
-  # list all the pdf files in the selected folder
-  input_filepaths <- (Sys.glob(file.path(input_directory,"*.pdf")))
-
-  if(is.null(output_filepath)){
-    #Choose output file interactively
-    output_filepath <-  tcltk::tclvalue(tcltk::tkgetSaveFile(filetypes = '{Pdf {.pdf}}'))
+  if(is.null(input_directory) & is.null(input_files)) {
+    input_directory <- tcltk::tk_choose.dir(caption = "Select directory which contains PDF fies")
   }
+  if(!is.null(input_directory)){input_filepaths <- (Sys.glob(file.path(input_directory, "*.pdf")))}
+  if(!is.null(input_files)){input_filepaths <- input_files}
 
-  # Construct a system command to pdftk
-  system_command <- paste("pdftk",
-                          paste(shQuote(input_filepaths), collapse = " "),
-                          "cat",
-                          "output",
-                          shQuote(output_filepath),
-                          sep = " ")
-  # Invoke the command
+  if (is.null(output_directory)) {
+    output_directory <- tcltk::tk_choose.dir(caption = "Select directory to save output")
+  }
+  output_filepath <- file.path(output_directory, paste(output_filename,
+                                                       ".pdf", sep = ""))
+  quoted_names <- paste0("\"", input_filepaths, "\"")
+  file_list <- paste(quoted_names, collapse = " ")
+  output_filepath <- paste0("\"", output_filepath, "\"")
+  system_command <- paste("pdftk", file_list, "cat", "output",
+                          output_filepath, sep = " ")
   system(command = system_command)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,9 @@ This package is still under development and this repository contains a developme
 
 #### First Install pdftk
 
-download and install [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/) NB: this is not an R package!
+download and install [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/). This is not an R package!
+
+NB: pdftk is known to hang indefinitely on macOS High Sierra. If this happens to you, [this version](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg) should work for macOS El Capitan (10.11), it also works on Sierra (10.12) and High Sierra (10.13).
 
 #### Then Install staplr
 You can install the stable version from CRAN.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Status](https://travis-ci.org/pridiltal/staplr.svg?branch=master)](https://travi
 
 -----
 
-[![Last-changedate](https://img.shields.io/badge/last%20change-2018--03--30-yellowgreen.svg)](/commits/master)
+[![Last-changedate](https://img.shields.io/badge/last%20change-2018--04--30-yellowgreen.svg)](/commits/master)
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
@@ -41,8 +41,14 @@ development version of the R package *staplr*.
 #### First Install pdftk
 
 download and install
-[pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/) NB: this
-is not an R package\!
+[pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/). This is
+not an R package\!
+
+NB: pdftk is known to hang indefinitely on macOS High Sierra. If this
+happens to you, [this
+version](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg)
+should work for macOS El Capitan (10.11), it also works on Sierra
+(10.12) and High Sierra (10.13).
 
 #### Then Install staplr
 

--- a/man/staple_pdf.Rd
+++ b/man/staple_pdf.Rd
@@ -4,16 +4,21 @@
 \alias{staple_pdf}
 \title{Merge multiple PDF files into one}
 \usage{
-staple_pdf(input_directory = NULL, output_filepath = NULL)
+staple_pdf(input_directory = NULL, input_files = NULL,
+  output_filename = "full_pdf", output_directory = NULL)
 }
 \arguments{
 \item{input_directory}{the path of the input PDF files.
-The default is set to NULL. IF NULL, it  prompt the user to
+The default is set to NULL. If NULL, it  prompt the user to
 select the folder interactively.}
 
-\item{output_filepath}{the path of the output output PDF file.
+\item{input_files}{a vector of input PDF files. The default is set to NULL. If NULL and \code{input_directory} is also NULL, the user is propted to select a folder interactively.}
+
+\item{output_filename}{the name of the output PDF file. The default is full_pdf.pdf.}
+
+\item{output_directory}{the path of the output PDF file.
 The default is set to NULL. IF NULL, it  prompt the user to
-select the folder interactivelye.}
+select the folder interactively.}
 }
 \value{
 this function returns a combined PDF document
@@ -37,7 +42,7 @@ pdf(file.path(dir, paste("plot", i, ".pdf", sep = "")))
 print(xyplot(iris[,1] ~ iris[,i], data = iris))
 dev.off()
 }
-output_file <- file.path(dir, paste('Full_pdf.pdf',  sep = ""))
+output_file <- file.path(dir, paste('full_pdf.pdf',  sep = ""))
 staple_pdf(input_directory = dir, output_file)
 }
 }


### PR DESCRIPTION
Hi

I changed the readme to add a note advising users what to do if their pdftk hangs infinitely on macOS high Sierra and other operating systems.

With staple_pdf(), I added an input_files argument and added a stop command if neither input_files or input_directory is NULL (one of them has to be otherwise it does not make sense).

I also cleaned up the documentation as output_filepath was a param but wasn't in the function call. I changed the default name of the pdf to full_pdf.pdf instead of Full_pdf.pdf because I don't think having capitals in names of files is particularly useful. Open to changing that though.

Cheers
Dan