### PR TITLE
Add some install instructions for Linux

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -51,6 +51,14 @@ download and install [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit
 
 NB: pdftk is known to hang indefinitely on macOS High Sierra. If this happens to you, [this version](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg) should work for macOS El Capitan (10.11), it also works on Sierra (10.12) and High Sierra (10.13).
 
+Installation instructions for Red Hat or CentOS distributions can be found here: https://www.pdflabs.com/docs/install-pdftk-on-redhat-or-centos/ 
+
+Packaged versions can be found for [Arch](https://aur.archlinux.org/packages/pdftk/) and [Ubuntu](https://packages.ubuntu.com/search?keywords=pdftk). On Ubuntu, for example, this means pdftk can be installed with the following command on [most](https://askubuntu.com/questions/1028522/how-can-i-install-pdftk-in-ubuntu-18-04-bionic) versions:
+
+```bash
+sudo apt install pdftk
+```
+
 #### Then Install staplr
 You can install the stable version from CRAN.
 


### PR DESCRIPTION
Great package, just used it to 'staple' two pdfs together for work, very useful!

When I first saw the package I thought pdftk was unavailable for Linux and it took some research to confirm it is - so I think this addition to the README will be useful to people coming to the package for the first time and should save people time researching how to get pdftk on Linux distros.