### PR TITLE
Overwrite finished version

### DIFF
--- a/R/fill_pdf.R
+++ b/R/fill_pdf.R
@@ -98,7 +98,7 @@ fdfEdit <- function(fieldToFill,annotatedFDF){
 #' pdfFile = system.file('testForm.pdf',package = 'staplr')
 #' idenfity_form_fields(pdfFile, 'testOutput.pdf')
 #' }
-idenfity_form_fields <- function(input_filepath = NULL, output_filepath = NULL,overwrite = FALSE){
+idenfity_form_fields <- function(input_filepath = NULL, output_filepath = NULL,overwrite = TRUE){
   if(is.null(input_filepath)){
     #Choose the pdf file interactively
     input_filepath <- file.choose(new = FALSE)
@@ -255,7 +255,7 @@ get_fdf_lines <- function(input_filepath){
 #' }
 #'
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-set_fields = function(input_filepath = NULL, output_filepath = NULL, fields, overwrite = FALSE){
+set_fields = function(input_filepath = NULL, output_filepath = NULL, fields, overwrite = TRUE){
   assertthat::assert_that(is.list(fields))
   if(is.null(input_filepath)){
     #Choose the pdf file interactively

--- a/R/remove_pages.R
+++ b/R/remove_pages.R
@@ -37,7 +37,7 @@
 #' @import utils
 #' @importFrom  stringr str_extract
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-remove_pages <- function(rmpages, input_filepath = NULL, output_filepath = NULL, overwrite = FALSE) {
+remove_pages <- function(rmpages, input_filepath = NULL, output_filepath = NULL, overwrite = TRUE) {
 
   assertthat::assert_that(is.numeric(rmpages))
 

--- a/R/rotate_pages.R
+++ b/R/rotate_pages.R
@@ -7,8 +7,10 @@
 #' See the reference for detailed usage of \code{pdftk}.
 #' @param rotatepages a vector of page numbers to be rotated
 #' @param page_rotation An integer value from the vector c(0, 90, 180, 270).
-#' Each option sets the page rotation as follows (in degrees):
-#' north: 0, east: 90, south: 180, west: 270
+#' Each option sets the page orientation as follows:
+#' north: 0, east: 90, south: 180, west: 270. Note that the orientation cannot be
+#' cummulatively changed (eg. 90 (east) will always turn the page so the beginning
+#' of the page is on the right side)
 #' @inheritParams input_filepath
 #' @inheritParams output_filepath
 #' @inheritParams overwrite

--- a/R/rotate_pages.R
+++ b/R/rotate_pages.R
@@ -41,7 +41,7 @@
 #' @import utils
 #' @importFrom  stringr str_extract
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-rotate_pages <- function(rotatepages, page_rotation = c(0,90,180,270), input_filepath = NULL, output_filepath = NULL, overwrite = FALSE) {
+rotate_pages <- function(rotatepages, page_rotation = c(0,90,180,270), input_filepath = NULL, output_filepath = NULL, overwrite = TRUE) {
 
   assertthat::assert_that(is.numeric(rotatepages))
   page_rotation <- match.arg(as.character(page_rotation), c(0, 90, 180, 270))

--- a/R/rotate_pdf.R
+++ b/R/rotate_pdf.R
@@ -5,8 +5,10 @@
 #'
 #' See the reference for detailed usage of \code{pdftk}.
 #' @param page_rotation An integer value from the vector c(0, 90, 180, 270).
-#' Each option sets the page rotation as follows (in degrees):
-#' north: 0, east: 90, south: 180, west: 270
+#' Each option sets the page orientation as follows:
+#' north: 0, east: 90, south: 180, west: 270. Note that the orientation cannot be
+#' cummulatively changed (eg. 90 (east) will always turn the page so the beginning
+#' of the page is on the right side)
 #' @inheritParams input_filepath
 #' @inheritParams output_filepath
 #' @inheritParams overwrite

--- a/R/rotate_pdf.R
+++ b/R/rotate_pdf.R
@@ -9,6 +9,7 @@
 #' north: 0, east: 90, south: 180, west: 270
 #' @inheritParams input_filepath
 #' @inheritParams output_filepath
+#' @inheritParams overwrite
 #' @return this function returns a PDF document with the rotated pages
 #' @author Priyanga Dilini Talagala
 #' @examples
@@ -34,7 +35,7 @@
 #' }
 #' @export
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-rotate_pdf <- function(page_rotation = c(0, 90, 180, 270),  input_filepath = NULL, output_filepath = NULL, overwrite = FALSE) {
+rotate_pdf <- function(page_rotation = c(0, 90, 180, 270),  input_filepath = NULL, output_filepath = NULL, overwrite = TRUE) {
 
   page_rotation <- match.arg(as.character(page_rotation),c(0, 90, 180, 270))
 

--- a/R/select_pages.R
+++ b/R/select_pages.R
@@ -6,12 +6,9 @@
 #'
 #' See the reference for detailed usage of \code{pdftk}.
 #' @param selpages a vector of page numbers to be selected
-#' @param input_filepath the path of the input PDF file.
-#' The default is set to NULL. IF NULL, it  prompt the user to
-#' select the folder interactively.
-#' @param output_filepath the path of the output PDF file.
-#' The default is set to NULL. IF NULL, it  prompt the user to
-#' select the folder interactivelye.
+#' @inheritParams input_filepath
+#' @inheritParams output_filepath
+#' @inheritParams overwrite
 #' @return this function returns a PDF document with the
 #' remaining pages
 #' @author Granville Matheson, Priyanga Dilini Talagala
@@ -40,7 +37,7 @@
 #' @import utils
 #' @importFrom  stringr str_extract
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-select_pages <- function(selpages, input_filepath = NULL, output_filepath = NULL) {
+select_pages <- function(selpages, input_filepath = NULL, output_filepath = NULL, overwrite = TRUE) {
 
   assertthat::assert_that(is.numeric(selpages))
 
@@ -85,8 +82,10 @@ select_pages <- function(selpages, input_filepath = NULL, output_filepath = NULL
                           "cat",
                           paste(unlist(selected_pages),collapse=" "),
                           "output",
-                          shQuote(output_filepath),
+                          "{shQuote(output_filepath)}",
                           sep = " ")
   # Invoke the command
-  system(command = system_command)
-}
+  fileIO(input_filepath = input_filepath,
+         output_filepath = output_filepath,
+         overwrite = overwrite,
+         system_command = system_command)}

--- a/R/split_from.R
+++ b/R/split_from.R
@@ -6,11 +6,10 @@
 #'
 #' See the reference for detailed usage of \code{pdftk}.
 #' @param pg_num A vector of non-negative integers. Split the pdf document into parts from the numbered pages.
-#' @param input_filepath the path of the input PDF file.
-#' The default is set to NULL. IF NULL, it  prompt the user to
-#' select the folder interactively.
+#' @inheritParams input_filepath
 #' @param output_directory the path of the output directory
 #' @param prefix A string for output filename prefix
+#' @inheritParams overwrite
 #' @return this function splits a single input PDF document into
 #' individual pages
 #' @author Priyanga Dilini Talagala and Ogan Mancarci
@@ -34,7 +33,8 @@
 #' }
 #' @export
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
-split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL, prefix = 'part') {
+split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL, prefix = 'part',
+                       overwrite = TRUE) {
 
   assertthat::assert_that(is.numeric(pg_num))
 
@@ -59,6 +59,10 @@ split_from <- function(pg_num, input_filepath = NULL, output_directory = NULL, p
     output_filepath <- file.path(output_directory,
                                  paste(prefix, stringr::str_pad(i,digits, pad = '0'),
                                        ".pdf",  sep = ""))
+
+    if(!overwrite & file.exists(output_filepath)){
+      stop(paste(output_filepath,'already exists. Set overwrite = TRUE to overwrite'))
+    }
 
     system_command <- paste("pdftk",
                             shQuote(input_filepath),

--- a/R/split_pdf.R
+++ b/R/split_pdf.R
@@ -5,9 +5,7 @@
 #' into individual pages.
 #'
 #' See the reference for detailed usage of \code{pdftk}.
-#' @param input_filepath the path of the input PDF file.
-#' The default is set to NULL. IF NULL, it  prompt the user to
-#' select the folder interactively.
+#' @inheritParams input_filepath
 #' @param output_directory the path of the output directory
 #' @param prefix A string for output filename prefix
 #' @return this function splits a single input PDF document into
@@ -63,7 +61,6 @@ split_pdf <- function(input_filepath = NULL, output_directory = NULL, prefix = '
 
   # Take the filepath arguments and format them for use in a system command
   output_filepath <- shQuote(paste0(output_directory, "/", prefix, "%0",digits,"d.pdf"))
-
   # Construct a system command to pdftk
   system_command <- paste("pdftk",
                           shQuote(input_filepath),

--- a/R/staple_pdf.R
+++ b/R/staple_pdf.R
@@ -8,9 +8,8 @@
 #' The default is set to NULL. If NULL, it  prompt the user to
 #' select the folder interactively.
 #' @param input_files a vector of input PDF files. The default is set to NULL. If NULL and \code{input_directory} is also NULL, the user is propted to select a folder interactively.
-#' @param output_filepath the path of the output PDF file.
-#' The default is set to NULL. IF NULL, it  prompt the user to
-#' select the folder interactively.
+#' @inheritParams output_filepath
+#' @inheritParams overwrite
 #' @return this function returns a combined PDF document
 #' @author Priyanga Dilini Talagala and Daniel Padfield
 #' @examples
@@ -33,7 +32,7 @@
 #' @importFrom tcltk tk_choose.dir
 #' @references \url{https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/}
 staple_pdf <- function(input_directory = NULL, input_files = NULL,
-                       output_filepath = NULL)
+                       output_filepath = NULL, overwrite = TRUE)
 {
   # set error if neither input_directory of input_files are null
   if(!is.null(input_directory) & !is.null(input_files)){
@@ -53,6 +52,10 @@ staple_pdf <- function(input_directory = NULL, input_files = NULL,
 
   input_filepaths <- normalizePath(input_filepaths, mustWork = TRUE)
   output_filepath <- normalizePath(output_filepath, mustWork = FALSE)
+
+  if(!overwrite & file.exists(output_filepath)){
+    stop(paste(output_filepath,'already exists. Set overwrite = TRUE to overwrite'))
+  }
 
   # Construct a system command to pdftk
   system_command <- paste("pdftk",

--- a/man/idenfity_form_fields.Rd
+++ b/man/idenfity_form_fields.Rd
@@ -5,7 +5,7 @@
 \title{Identify text form fields}
 \usage{
 idenfity_form_fields(input_filepath = NULL, output_filepath = NULL,
-  overwrite = FALSE)
+  overwrite = TRUE)
 }
 \arguments{
 \item{input_filepath}{the path of the input PDF file. The default is set to

--- a/man/remove_pages.Rd
+++ b/man/remove_pages.Rd
@@ -5,7 +5,7 @@
 \title{Remove selected pages from a file}
 \usage{
 remove_pages(rmpages, input_filepath = NULL, output_filepath = NULL,
-  overwrite = FALSE)
+  overwrite = TRUE)
 }
 \arguments{
 \item{rmpages}{a vector of page numbers to be removed}

--- a/man/rotate_pages.Rd
+++ b/man/rotate_pages.Rd
@@ -5,14 +5,16 @@
 \title{Rotate selected pages of a pdf file}
 \usage{
 rotate_pages(rotatepages, page_rotation = c(0, 90, 180, 270),
-  input_filepath = NULL, output_filepath = NULL, overwrite = FALSE)
+  input_filepath = NULL, output_filepath = NULL, overwrite = TRUE)
 }
 \arguments{
 \item{rotatepages}{a vector of page numbers to be rotated}
 
 \item{page_rotation}{An integer value from the vector c(0, 90, 180, 270).
-Each option sets the page rotation as follows (in degrees):
-north: 0, east: 90, south: 180, west: 270}
+Each option sets the page orientation as follows:
+north: 0, east: 90, south: 180, west: 270. Note that the orientation cannot be
+cummulatively changed (eg. 90 (east) will always turn the page so the beginning
+of the page is on the right side)}
 
 \item{input_filepath}{the path of the input PDF file. The default is set to
 NULL. IF NULL, it  prompt the user to select the folder interactively.}

--- a/man/rotate_pdf.Rd
+++ b/man/rotate_pdf.Rd
@@ -5,18 +5,22 @@
 \title{Rotate entire pdf document}
 \usage{
 rotate_pdf(page_rotation = c(0, 90, 180, 270), input_filepath = NULL,
-  output_filepath = NULL, overwrite = FALSE)
+  output_filepath = NULL, overwrite = TRUE)
 }
 \arguments{
 \item{page_rotation}{An integer value from the vector c(0, 90, 180, 270).
-Each option sets the page rotation as follows (in degrees):
-north: 0, east: 90, south: 180, west: 270}
+Each option sets the page orientation as follows:
+north: 0, east: 90, south: 180, west: 270. Note that the orientation cannot be
+cummulatively changed (eg. 90 (east) will always turn the page so the beginning
+of the page is on the right side)}
 
 \item{input_filepath}{the path of the input PDF file. The default is set to
 NULL. IF NULL, it  prompt the user to select the folder interactively.}
 
 \item{output_filepath}{the path of the output PDF file. The default is set to
 NULL. IF NULL, it  prompt the user to select the folder interactively.}
+
+\item{overwrite}{If a file exists in \code{output_filepath}, should it be overwritten.}
 }
 \value{
 this function returns a PDF document with the rotated pages

--- a/man/select_pages.Rd
+++ b/man/select_pages.Rd
@@ -4,18 +4,19 @@
 \alias{select_pages}
 \title{Select pages from a file}
 \usage{
-select_pages(selpages, input_filepath = NULL, output_filepath = NULL)
+select_pages(selpages, input_filepath = NULL, output_filepath = NULL,
+  overwrite = TRUE)
 }
 \arguments{
 \item{selpages}{a vector of page numbers to be selected}
 
-\item{input_filepath}{the path of the input PDF file.
-The default is set to NULL. IF NULL, it  prompt the user to
-select the folder interactively.}
+\item{input_filepath}{the path of the input PDF file. The default is set to
+NULL. IF NULL, it  prompt the user to select the folder interactively.}
 
-\item{output_filepath}{the path of the output PDF file.
-The default is set to NULL. IF NULL, it  prompt the user to
-select the folder interactivelye.}
+\item{output_filepath}{the path of the output PDF file. The default is set to
+NULL. IF NULL, it  prompt the user to select the folder interactively.}
+
+\item{overwrite}{If a file exists in \code{output_filepath}, should it be overwritten.}
 }
 \value{
 this function returns a PDF document with the

--- a/man/set_fields.Rd
+++ b/man/set_fields.Rd
@@ -5,7 +5,7 @@
 \title{Set fields of a pdf form}
 \usage{
 set_fields(input_filepath = NULL, output_filepath = NULL, fields,
-  overwrite = FALSE)
+  overwrite = TRUE)
 }
 \arguments{
 \item{input_filepath}{the path of the input PDF file. The default is set to

--- a/man/split_from.Rd
+++ b/man/split_from.Rd
@@ -5,18 +5,19 @@
 \title{Splits single input PDF document into parts from given points}
 \usage{
 split_from(pg_num, input_filepath = NULL, output_directory = NULL,
-  prefix = "part")
+  prefix = "part", overwrite = TRUE)
 }
 \arguments{
 \item{pg_num}{A vector of non-negative integers. Split the pdf document into parts from the numbered pages.}
 
-\item{input_filepath}{the path of the input PDF file.
-The default is set to NULL. IF NULL, it  prompt the user to
-select the folder interactively.}
+\item{input_filepath}{the path of the input PDF file. The default is set to
+NULL. IF NULL, it  prompt the user to select the folder interactively.}
 
 \item{output_directory}{the path of the output directory}
 
 \item{prefix}{A string for output filename prefix}
+
+\item{overwrite}{If a file exists in \code{output_filepath}, should it be overwritten.}
 }
 \value{
 this function splits a single input PDF document into

--- a/man/split_pdf.Rd
+++ b/man/split_pdf.Rd
@@ -8,9 +8,8 @@ split_pdf(input_filepath = NULL, output_directory = NULL,
   prefix = "page_")
 }
 \arguments{
-\item{input_filepath}{the path of the input PDF file.
-The default is set to NULL. IF NULL, it  prompt the user to
-select the folder interactively.}
+\item{input_filepath}{the path of the input PDF file. The default is set to
+NULL. IF NULL, it  prompt the user to select the folder interactively.}
 
 \item{output_directory}{the path of the output directory}
 

--- a/man/staple_pdf.Rd
+++ b/man/staple_pdf.Rd
@@ -5,7 +5,7 @@
 \title{Merge multiple PDF files into one}
 \usage{
 staple_pdf(input_directory = NULL, input_files = NULL,
-  output_filepath = NULL)
+  output_filepath = NULL, overwrite = TRUE)
 }
 \arguments{
 \item{input_directory}{the path of the input PDF files.
@@ -14,9 +14,10 @@ select the folder interactively.}
 
 \item{input_files}{a vector of input PDF files. The default is set to NULL. If NULL and \code{input_directory} is also NULL, the user is propted to select a folder interactively.}
 
-\item{output_filepath}{the path of the output PDF file.
-The default is set to NULL. IF NULL, it  prompt the user to
-select the folder interactively.}
+\item{output_filepath}{the path of the output PDF file. The default is set to
+NULL. IF NULL, it  prompt the user to select the folder interactively.}
+
+\item{overwrite}{If a file exists in \code{output_filepath}, should it be overwritten.}
 }
 \value{
 this function returns a combined PDF document

--- a/tests/testthat/test_general.R
+++ b/tests/testthat/test_general.R
@@ -188,4 +188,9 @@ test_that('overwrite',{
   expect_equal(newDims[3],oldDims[2])
 
 
+  # ensure that the page is removed so the new page 1 is the old page 2
+  oldPage2 = pdftools::pdf_text(tempFile)[2]
+  select_pages(selpages = 2, tempFile, tempFile,overwrite = TRUE)
+  expect_true(oldPage2 == pdftools::pdf_text(tempFile)[1])
+
 })

--- a/tests/testthat/test_general.R
+++ b/tests/testthat/test_general.R
@@ -164,6 +164,7 @@ test_that('overwrite',{
   fields$TextField1$value <- 'this is text'
   set_fields(pdfFile,tempFile,fields,overwrite = TRUE)
   expect_true(grepl('this is text', pdftools::pdf_text(tempFile)[1]))
+  expect_error(set_fields(pdfFile,tempFile,fields,overwrite = FALSE),'already exists')
 
 
   oldSecondPage = pdftools::pdf_text(tempFile)[2]
@@ -192,5 +193,16 @@ test_that('overwrite',{
   oldPage2 = pdftools::pdf_text(tempFile)[2]
   select_pages(selpages = 2, tempFile, tempFile,overwrite = TRUE)
   expect_true(oldPage2 == pdftools::pdf_text(tempFile)[1])
+
+  pdfFile <- system.file('testForm.pdf',package = 'staplr')
+  file.copy(pdfFile,tempFile,overwrite = TRUE)
+  tempDir = tempfile()
+  dir.create(tempDir)
+  split_from(tempFile,pg_num = 2,output_directory = tempDir)
+  expect_error(split_from(tempFile,pg_num = 2,output_directory = tempDir,overwrite = FALSE),'already exists')
+
+  staple_pdf(input_directory = tempDir,output_filepath = tempFile)
+  expect_error(staple_pdf(input_directory = tempDir,output_filepath = tempFile,overwrite = FALSE), 'already exists')
+
 
 })


### PR DESCRIPTION
What is discussed before. mostly unchanged. The only difference is the default behavior is `overwrite = TRUE` now to be consistent with most other R functions and its past self. also split_pdf doesn't have an overwrite variable now because it didn't have a quick way of detecting what the output file names would be.

also attempts to clarify the documentation for rotate functions. possibly poorly