### PR TITLE
Make get_fields faster by using rJava

### DIFF
--- a/R/fill_pdf.R
+++ b/R/fill_pdf.R
@@ -408,8 +408,6 @@ get_fields <- function(input_filepath = NULL, convert_field_names = FALSE, encod
 }
 
 rjava_get_fields = function(f) {
-  jar_path = system.file('pdftk-java/pdftk.jar', package = 'staplr', mustWork = TRUE)
-  rJava::.jaddClassPath(jar_path)
   # instead of an output file, write the output to this byte array so we can
   # send it directly back to R
   out = rJava::.jnew('java/io/ByteArrayOutputStream')

--- a/R/onload.R
+++ b/R/onload.R
@@ -1,5 +1,6 @@
 .onLoad <- function(libname, pkgname){
-  rJava::.jinit()
+  staplr_jar <- system.file('pdftk-java/pdftk.jar', package = pkgname, mustWork = TRUE)
+  rJava::.jpackage(pkgname, morePaths = staplr_jar, lib.loc = libname)
   jv <- rJava::.jcall("java/lang/System", "S", "getProperty", "java.runtime.version")
   if(substr(jv, 1L, 2L) == "1.") {
     jvn <- as.numeric(paste0(strsplit(jv, "[.]")[[1L]][1:2], collapse = "."))

--- a/R/onload.R
+++ b/R/onload.R
@@ -1,6 +1,6 @@
 .onLoad <- function(libname, pkgname){
-  staplr_jar <- system.file('pdftk-java/pdftk.jar', package = pkgname, mustWork = TRUE)
-  rJava::.jpackage(pkgname, morePaths = staplr_jar, lib.loc = libname)
+  pdftk_jar <- system.file('pdftk-java/pdftk.jar', package = pkgname, mustWork = TRUE)
+  rJava::.jpackage(pkgname, morePaths = pdftk_jar, lib.loc = libname)
   jv <- rJava::.jcall("java/lang/System", "S", "getProperty", "java.runtime.version")
   if(substr(jv, 1L, 2L) == "1.") {
     jvn <- as.numeric(paste0(strsplit(jv, "[.]")[[1L]][1:2], collapse = "."))


### PR DESCRIPTION
There seems to be an overhead associated with calling Java from the `system` function, at least for me on Ubuntu. For `get_fields`, I was able to call some of the lower-level pdftk functions directly with rJava, and the result is more than twice as fast on my computer. (All the tests still pass.)

If this change is merged, we may also want to change the onload.R file to use `.jpackage` instead of `.jinit`. This is relevant to the new rJava code because we have to add the pdftk jar file to the classpath.